### PR TITLE
Fix bug where page does not get reset when redrawing suggest list

### DIFF
--- a/redquerybuilder-core/src/main/java/com/redspr/redquerybuilder/core/client/expression/SuggestEditorWidget.java
+++ b/redquerybuilder-core/src/main/java/com/redspr/redquerybuilder/core/client/expression/SuggestEditorWidget.java
@@ -303,6 +303,7 @@ public class SuggestEditorWidget<T> extends Composite implements HasValue<T> {
             @Override
             public void onBlur(BlurEvent event) {
                 active = false;
+                scrollDisplay.page = 0;
             }
         });
 


### PR DESCRIPTION
This updates fixes a problem where secondary clicks for the suggest dropdown do not properly lazy load the suggest data.
